### PR TITLE
fix(deps): pin golang.org/x/text to v0.41.0 (CVE-2026-56852)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,4 +35,8 @@ replace (
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2 // CVE-2021-3121
 	// CVE-2022-41717
 	golang.org/x/net => golang.org/x/net v0.58.0
+	// CVE-2026-56852: infinite loop in unicode/norm on invalid UTF-8.
+	// Pulled in transitively by golang.org/x/crypto; not reachable from this
+	// module's code, but nancy gates go-build on the module graph.
+	golang.org/x/text => golang.org/x/text v0.41.0
 )


### PR DESCRIPTION
Pins `golang.org/x/text` to v0.41.0 to patch CVE-2026-56852 / GO-2026-5970 (infinite loop in `unicode/norm` on invalid UTF-8).

`nancy` audits the full module graph and gates the shared `go-build` job, so this CVE was failing CI on **every** open PR in this repo, including the Align files PR #114.

### Why a `replace` and not `go get`

`x/text` is transitive-only here (via `golang.org/x/crypto v0.53.0`) and is not reachable from this module's packages. So `go get golang.org/x/text@v0.41.0` followed by `go mod tidy` silently reverts — module-graph pruning drops the unused explicit require and the selected version falls back to x/crypto's v0.38.0. A `replace` survives `tidy` and is already the convention in this file for the `golang.org/x/net` CVE-2022-41717 mitigation.

### Verification

- `go list -m golang.org/x/text` → `v0.38.0 => v0.41.0`
- `go mod tidy -diff` → clean
- `go build ./...` → OK
- `go test ./...` → all packages pass

Fleet-wide tracking: giantswarm/github#5786